### PR TITLE
Persistance through glassfish

### DIFF
--- a/docs/configure_db.md
+++ b/docs/configure_db.md
@@ -1,28 +1,35 @@
-#How to Connect Local DB:
+#How to Connect Local DB, with glassfish:
 
-1. You will first need a local DB setup with tables setup corresponding to the TokenMap.java and
-ClientCredentials.java classes in the /src/main/java/persistence directory.
+1. Before you start up glassfish you will need to need to download the JDBC driver so you can add it to glassfish. For 
+an example I will show using PostgreSQL. [Link to JDBC Driver PostgreSQL](https://jdbc.postgresql.org/download.html)
+(version 42.2.5 didn't work for me so I used [42.2.4](https://jdbc.postgresql.org/download/postgresql-42.2.4.jar))
 
-2. You will the need to add the relevant SQL driver dependency for your database to the pom.xml file. Example for a 
-PostgreSQL db here:
+2. Once you have downloaded the .jar file you will need to add it to your local glassfish install, to do this put the
+.jar file in this '{domain_path}/lib' directory.
+
+3. Now you need to start your domain so you can access the glassfish administration console.
+
+4. Once in the admin console using the left hand side navigation menu go to resouces/JDBC and click on 'JDBC Connection
+Pools' option.
+
+5. Create a new connection pool. On the 'New JDBC Connection Pool (Step 1 of 2)' page set the pool name to whatever you 
+want, the resource type should be java.sql.Driver, database driver vendor should be your chosen vendor for me that would
+be PostgreSQL. Now click next.
+
+6. On the 'New JDBC Connection Pool (Step 2 of 2)' page you should set Initial & Minimum Pool Size to '0' then enter
+your DB's 'URL', 'User' and 'Password' in the Additional Properties section at the bottom of the page. Now click Finish.
+
+7. Now open up that connection pool and click on the Ping button to test you have set it up correctly.
+
+8. Now we need to create a JDBC Resource, to do this you need to repeat step 4. but instead of clicking the 
+'JDBC Connection Pools' option you need to click on the 'JDBC Resources' option.
+
+9. Now click new, and set the 'JNDI Name to whatever' and for the 'Pool Name' option select the pool you just created
+from the drop down list. Then click ok.
+
+10. Now in the application you should modify the persistance.xml file located in the '/src/main/java/resources/META-INF'
+directory. All you need to change is the line below replacing 'FitbitDatabase' with the name you gave to the
+JDBC Resource you created.
 ```xml
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>42.2.5.jre7</version>
-        </dependency>
+<jta-data-source>FitbitDatabase</jta-data-source>
 ```
-3. Then to connect to this database you will need to navigate to the persistence.xml file, it can be found at
-/src/main/resources/META-INF/persistence.xml
-
-4. In this file you will need to change 4 properties the 'hibernate.connection.url', 'hibernate.connection.driver_class'
-, 'hibernate.connection.username' and 'hibernate.connection.password'. Here is an example of what those settings may
-look like if you where using a local PostgreSQL DB.
-```xml
-        <property name="hibernate.connection.url" value="jdbc:postgresql://localhost:5432/example_db"/>
-        <property name="hibernate.connection.driver_class" value="org.postgresql.Driver"/>
-        <property name="hibernate.connection.username" value="user"/>
-        <property name="hibernate.connection.password" value="password"/>
-```
-
-5. Now when you run 'mvn test' the test for database storage should run.

--- a/fitbit-ingest-service.iml
+++ b/fitbit-ingest-service.iml
@@ -20,10 +20,10 @@
         <setting name="validation-enabled" value="true" />
         <setting name="provider-name" value="" />
         <datasource-mapping>
-          <factory-entry name="fitbitPU" />
+          <factory-entry name="fitbitPU" value="58e8053c-14bd-4851-91d7-27e4f1926387" />
           <factory-entry name="test-fitbitPU" />
         </datasource-mapping>
-        <deploymentDescriptor name="persistence.xml" url="file://$MODULE_DIR$/src/test/resources/META-INF/persistence.xml" />
+        <deploymentDescriptor name="persistence.xml" url="file://$MODULE_DIR$/src/main/resources/META-INF/persistence.xml" />
       </configuration>
     </facet>
   </component>
@@ -49,8 +49,10 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-suite-api:1.1.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.10.19" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.h2database:h2:1.4.192" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax:javaee-api:8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sun.mail:javax.mail:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:javax.servlet-api:4.0.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.enterprise:cdi-api:2.0.SP1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.el:javax.el-api:3.0.0" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -23,18 +23,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.192</version>
             <scope>test</scope>
         </dependency>
         <!--These dependencies, ...-->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,21 +42,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>2.0.SP1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.faces</groupId>
+            <groupId>com.sun.faces</groupId>
             <artifactId>jsf-api</artifactId>
-            <version>2.1</version>
-            <scope>provided</scope>
+            <version>2.2.18</version>
         </dependency>
         <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>java.jdbc</artifactId>
-            <version>0.7.8</version>
+            <groupId>com.sun.faces</groupId>
+            <artifactId>jsf-impl</artifactId>
+            <version>2.2.18</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -67,11 +60,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
             <version>5.3.7.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/persistence/StorageManager.java
+++ b/src/main/java/persistence/StorageManager.java
@@ -1,7 +1,5 @@
 package persistence;
 
-import org.hibernate.service.spi.ServiceException;
-
 import javax.persistence.*;
 import javax.persistence.EntityManager;
 import java.io.Serializable;
@@ -15,7 +13,6 @@ import java.io.Serializable;
  */
 public class StorageManager implements Serializable {
 
-    @PersistenceContext
     private EntityManager em;
 
     /**

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -3,19 +3,26 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.2"
              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
 
-    <persistence-unit name="fitbitPU">
+    <!--<persistence-unit name="fitbitPU" transaction-type="JTA">
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
         <class>persistence.TokenMap</class>
         <class>persistence.ClientCredentials</class>
         <properties>
-            <property name="hibernate.connection.url" value=""/>
-            <property name="hibernate.connection.driver_class" value=""/>
-            <property name="hibernate.connection.username" value=""/>
-            <property name="hibernate.connection.password" value=""/>
+            <property name="hibernate.connection.url" value="jdbc:postgresql://localhost:5432/fitbit_digest_db"/>
+            <property name="hibernate.connection.driver_class" value="org.postgresql.Driver"/>
+            <property name="hibernate.connection.username" value="james"/>
+            <property name="hibernate.connection.password" value="password"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
             <property name="hibernate.archive.autodetection" value="class"/>
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.format_sql" value="true"/>
             <property name="hibernate.hbm2ddl.auto" value="update"/>
         </properties>
+    </persistence-unit>-->
+
+    <persistence-unit name="fitbitPU" transaction-type="JTA">
+        <jta-data-source>FitbitDatabase</jta-data-source>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties/>
     </persistence-unit>
 </persistence>

--- a/src/test/java/persistence/PersistenceTest.java
+++ b/src/test/java/persistence/PersistenceTest.java
@@ -6,9 +6,6 @@ import org.hibernate.jdbc.Work;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
-import persistence.StorageManager;
-
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;


### PR DESCRIPTION
Modified persistence code so that when the application is deployed to glassfish persistance can be used. This required some administration setup in the glassfish admin console which i have documented in [config_db.md](https://github.com/sem5640-2018/fitbit-ingest-service/blob/development/docs/configure_db.md).