### PR TITLE
Tweak DB env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ ENV ABERFITNESS_CLI_SECRET DavidBeans
 
 ENV DB_HOSTNAME database
 ENV DB_PORT 3306
-ENV DB_NAME fitbit-ingest
-ENV DB_USER root
-ENV DB_PASS password
+ENV DB_NAME fitbit-ingest-service
+ENV DB_USERNAME root
+ENV DB_PASSWORD password
 
 ENV APP_BASE_URL http://localhost:8080
 ENV SYS_BASE_URL NOT_SET

--- a/src/main/webapp/WEB-INF/glassfish-resources.xml
+++ b/src/main/webapp/WEB-INF/glassfish-resources.xml
@@ -9,8 +9,8 @@
                               max-pool-size="32"
                               steady-pool-size="8">
             <property name="URL" value="jdbc:mariadb://${ENV=DB_HOSTNAME}:${ENV=DB_PORT}/${ENV=DB_NAME}"/>
-            <property name="User" value="${ENV=DB_USER}"/>
-            <property name="Password" value="${ENV=DB_PASS}"/>
+            <property name="User" value="${ENV=DB_USERNAME}"/>
+            <property name="Password" value="${ENV=DB_PASSWORD}"/>
         </jdbc-connection-pool>
 
         <!-- Creates a DataSource called "jdbc/testDS" for accessing the connection pool -->


### PR DESCRIPTION
This tweaks the env. variable names on fitbit ingest. Normally I would change them in the env. file, but as that requires me to do it by hand for the example and staging copy I thought it would be easier to tweak here.